### PR TITLE
Remove duplicate "Frequently Asked Questions" text

### DIFF
--- a/src/components/help/articles/Welcome.jsx
+++ b/src/components/help/articles/Welcome.jsx
@@ -13,8 +13,6 @@ export default class Welcome extends Component {
 
 //F1-F12, F43
     return (
-      <div>
-      <p>Frequently Asked Questions</p>
       <Article>
         <PaperApp />
         <Standard title={help.newAppTitle} body={help.newAppBody} />
@@ -31,7 +29,6 @@ export default class Welcome extends Component {
         <Standard title={help.newAppTitle} body={help.newAppBody} />
         <Standard title={help.disagreeTitle} body={help.disagreeBody} />
       </Article>
-      </div>
     )
   }
 }


### PR DESCRIPTION
This text is left over from previous attempts to put "Frequently Asked Questions" and "Definitions" text on the help pages.