### PR TITLE
Correct edit link bahavior on Summary slide

### DIFF
--- a/src/components/application/Link.jsx
+++ b/src/components/application/Link.jsx
@@ -3,13 +3,31 @@ import { observer } from 'mobx-react'
 
 @observer
 class Link extends Component {
+  constructor(props, context) {
+    super(props, context);
+    this.id = props.id
+    this.handleClick = this.handleClick.bind(this);
+  }
+
+  handleClick(e) {
+    e.preventDefault()
+    this.context.navigationData.jumpTo(this.id)
+  }
+
   render() {
-    return <a href={`#/${this.props.id}`}>{this.props.children}</a>
+    return <a href={`#/${this.id}`}
+              onClick={this.handleClick}>{this.props.children}</a>
   }
 }
 
 Link.propTypes = {
   id: PropTypes.string.isRequired
+}
+
+Link.contextTypes = {
+  navigationData: PropTypes.shape({
+    jumpTo: PropTypes.func.isRequired
+  }).isRequired
 }
 
 export default Link

--- a/src/stores/NavigationData.js
+++ b/src/stores/NavigationData.js
@@ -199,6 +199,10 @@ export default class NavigationData {
   }
 
   @action jump() {
-    window.location.replace('#/' + this.jumptSlide.id)
+    window.location.replace('#/' + this.jumpSlide.id)
+  }
+
+  @action jumpTo(id) {
+    window.location.replace(`#/${id}`)
   }
 }


### PR DESCRIPTION
Don't use a raw link, so that Summary slide doesn't get pushed onto history stack.