### PR TITLE
Parameterize assistance program accronyms

### DIFF
--- a/src/components/help/topics/WhatIncome.jsx
+++ b/src/components/help/topics/WhatIncome.jsx
@@ -335,7 +335,11 @@ export default class WhatIncome extends Component {
             <FormattedMessage
                 id="help.topic.WhatIncome.answer45"
                 description="Answer for the applicable income help topic."
-                defaultMessage="Cash  value of benefits from SNAP or FDPIR"
+                defaultMessage="Cash value of benefits from {snapAccronym} or {fdpirAccronym}"
+                values={{
+                  snapAccronym: assistanceProgramsVar.snap.accronym,
+                  fdpirAccronym: assistanceProgramsVar.fdpir.accronym
+                }}
             />
           </li>
           <li>

--- a/translations/EMPTY.json
+++ b/translations/EMPTY.json
@@ -2749,7 +2749,7 @@
   "help.topic.WhatIncome.answer44": "",
 
   // Answer for the applicable income help topic.
-  // English: "Cash  value of benefits from SNAP or FDPIR"
+  // English: "Cash value of benefits from {snapAccronym} or {fdpirAccronym}"
   "help.topic.WhatIncome.answer45": "",
 
   // Answer for the applicable income help topic.
@@ -2845,5 +2845,5 @@
 
   /***/
 
-  "NOTE": "All comments must be deleted before use (to create a valid JSON file). Message definitions version 1480306771681."
+  "NOTE": "All comments must be deleted before use (to create a valid JSON file). Message definitions version 1480308290660."
 }


### PR DESCRIPTION
@TimOPI — is this a good idea?

I notices a JavaScript error complaining about missing variable value when switching to Spanish. This provides the value and updates the English version to match.